### PR TITLE
VTK Support

### DIFF
--- a/omf/base.py
+++ b/omf/base.py
@@ -184,6 +184,11 @@ class ProjectElement(ContentModel):
                 )
         return True
 
+    def toVTK(self):
+        """Convert the project element to a VTK data structure.
+        This must be overridden by subclasses."""
+        raise NotImplementedError()
+
 
 class Project(ContentModel):
     """OMF Project for serializing to .omf file"""

--- a/omf/lineset.py
+++ b/omf/lineset.py
@@ -70,18 +70,32 @@ class LineSetElement(ProjectElement):
         cells = vtk.vtkCellArray()
         pts = vtk.vtkPoints()
 
+        # Make a data array for grouping the line segments
+        data = vtk.vtkIntArray()
+        data.SetNumberOfValues(self.geometry.num_cells - 1)
+        data.SetName('Line Index')
+
+        # Generate VTK Points from the vertices
         for v in self.geometry.vertices:
             pts.InsertNextPoint(v[0],v[1],v[2])
 
+        last = self.geometry.segments[0][0]
+        segi = 0
         for i in range(len(self.geometry.segments)-1):
+            # Create a VTK Line cell for each segment
             seg = self.geometry.segments[i]
             aLine = vtk.vtkLine()
             aLine.GetPointIds().SetId(0, seg[0])
             aLine.GetPointIds().SetId(1, seg[1])
             cells.InsertNextCell(aLine)
+            # Group segments by connectivity:
+            if seg[0] != last:
+                segi += 1
+            last = seg[1]
+            data.SetValue(i, segi)
 
+        # Generate the output
         output.SetPoints(pts)
         output.SetLines(cells)
-
-        # TODO: Add cell data to allow coloring by line:
+        output.GetCellData().AddArray(data)
         return output

--- a/omf/lineset.py
+++ b/omf/lineset.py
@@ -77,8 +77,8 @@ class LineSetElement(ProjectElement):
         indexArr.SetName('Line Index')
 
         # Generate VTK Points from the vertices
-        for v in self.geometry.vertices:
-            pts.InsertNextPoint(v[0],v[1],v[2])
+        pts.SetNumberOfPoints(self.geometry.num_nodes)
+        pts.SetData(nps.numpy_to_vtk(self.geometry.vertices))
 
         last = self.geometry.segments[0][0]
         segi = 0

--- a/omf/lineset.py
+++ b/omf/lineset.py
@@ -61,3 +61,27 @@ class LineSetElement(ProjectElement):
         choices=('line', 'borehole'),
         default='line'
     )
+
+    def toVTK(self):
+        """Convert the line set to a ``vtkPloyData`` data object."""
+        import vtk
+
+        output = vtk.vtkPolyData()
+        cells = vtk.vtkCellArray()
+        pts = vtk.vtkPoints()
+
+        for v in self.geometry.vertices:
+            pts.InsertNextPoint(v[0],v[1],v[2])
+
+        for i in range(len(self.geometry.segments)-1):
+            seg = self.geometry.segments[i]
+            aLine = vtk.vtkLine()
+            aLine.GetPointIds().SetId(0, seg[0])
+            aLine.GetPointIds().SetId(1, seg[1])
+            cells.InsertNextCell(aLine)
+
+        output.SetPoints(pts)
+        output.SetLines(cells)
+
+        # TODO: Add cell data to allow coloring by line:
+        return output

--- a/omf/pointset.py
+++ b/omf/pointset.py
@@ -52,3 +52,34 @@ class PointSetElement(ProjectElement):
         choices=('point', 'collar', 'blasthole'),
         default='point'
     )
+
+    def toVTK(self):
+        """Convert the point set to a ``vtkPloyData`` data object
+        which contatins the point set."""
+        import vtk
+        import numpy as np
+        from vtk.util import numpy_support as nps
+
+        output = vtk.vtkPolyData()
+        points = self.geometry.vertices
+        npoints = self.geometry.num_nodes
+
+        # Make VTK cells array
+        cells = np.hstack((np.ones((npoints, 1)),
+                           np.arange(npoints).reshape(-1, 1)))
+        cells = np.ascontiguousarray(cells, dtype=np.int64)
+        vtkcells = vtk.vtkCellArray()
+        vtkcells.SetCells(npoints, nps.numpy_to_vtkIdTypeArray(cells, deep=True))
+
+        # Convert points to vtk object
+        pts = vtk.vtkPoints()
+        for r in points:
+            pts.InsertNextPoint(r[0],r[1],r[2])
+
+        # Create polydata
+        pdata = vtk.vtkPolyData()
+        pdata.SetPoints(pts)
+        pdata.SetVerts(vtkcells)
+
+        # TODO: handle textures
+        return pdata

--- a/omf/pointset.py
+++ b/omf/pointset.py
@@ -60,7 +60,6 @@ class PointSetElement(ProjectElement):
         import numpy as np
         from vtk.util import numpy_support as nps
 
-        output = vtk.vtkPolyData()
         points = self.geometry.vertices
         npoints = self.geometry.num_nodes
 
@@ -74,12 +73,20 @@ class PointSetElement(ProjectElement):
         # Convert points to vtk object
         pts = vtk.vtkPoints()
         for r in points:
-            pts.InsertNextPoint(r[0],r[1],r[2])
+            pts.InsertNextPoint(r[0], r[1], r[2])
 
         # Create polydata
-        pdata = vtk.vtkPolyData()
-        pdata.SetPoints(pts)
-        pdata.SetVerts(vtkcells)
+        output = vtk.vtkPolyData()
+        output.SetPoints(pts)
+        output.SetVerts(vtkcells)
 
         # TODO: handle textures
-        return pdata
+
+        # Now add point data:
+        for data in self.data:
+            arr = data.array.array
+            c = nps.numpy_to_vtk(num_array=arr)
+            c.SetName(data.name)
+            output.GetPointData().AddArray(c)
+
+        return output

--- a/omf/pointset.py
+++ b/omf/pointset.py
@@ -72,8 +72,8 @@ class PointSetElement(ProjectElement):
 
         # Convert points to vtk object
         pts = vtk.vtkPoints()
-        for r in points:
-            pts.InsertNextPoint(r[0], r[1], r[2])
+        pts.SetNumberOfPoints(self.geometry.num_nodes)
+        pts.SetData(nps.numpy_to_vtk(points))
 
         # Create polydata
         output = vtk.vtkPolyData()

--- a/omf/surface.py
+++ b/omf/surface.py
@@ -64,17 +64,13 @@ class SurfaceGeometry(ProjectElementGeometry):
         pts.SetData(nps.numpy_to_vtk(self.vertices))
 
         # Generate the triangle cells
-        import time
-        start_time = time.time()
-        for t in self.triangles:
-            # TODO: this desperately need optimizing
-            triangle = vtk.vtkTriangle()
-            triangle.GetPointIds().SetId(0, t[0])
-            triangle.GetPointIds().SetId(1, t[1])
-            triangle.GetPointIds().SetId(2, t[2])
-            cells.InsertNextCell(triangle)
-        print("--- %s seconds ---" % (time.time() - start_time))
+        cellConn = self.triangles.array
+        cellsMat = np.concatenate((np.ones((cellConn.shape[0], 1), dtype=np.int64)*cellConn.shape[1], cellConn), axis=1).ravel()
+        cells = vtk.vtkCellArray()
+        cells.SetNumberOfCells(cellConn.shape[0])
+        cells.SetCells(cellConn.shape[0], nps.numpy_to_vtkIdTypeArray(cellsMat, deep=True))
 
+        # Add to output
         output.SetPoints(pts)
         output.SetCells(vtk.VTK_TRIANGLE, cells)
         return output

--- a/omf/surface.py
+++ b/omf/surface.py
@@ -60,8 +60,8 @@ class SurfaceGeometry(ProjectElementGeometry):
         cells = vtk.vtkCellArray()
 
         # Generate the points
-        for v in self.vertices:
-            pts.InsertNextPoint(v[0], v[1], v[2])
+        pts.SetNumberOfPoints(self.num_nodes)
+        pts.SetData(nps.numpy_to_vtk(self.vertices))
 
         # Generate the triangle cells
         for t in self.triangles:

--- a/omf/surface.py
+++ b/omf/surface.py
@@ -49,6 +49,32 @@ class SurfaceGeometry(ProjectElementGeometry):
             raise ValueError('Triangles expects more vertices than provided')
         return True
 
+    def toVTK(self):
+        """Convert the triangulated surface to a ``vtkUnstructuredGrid`` object
+        """
+        import vtk
+        from vtk.util import numpy_support as nps
+
+        output = vtk.vtkUnstructuredGrid()
+        pts = vtk.vtkPoints()
+        cells = vtk.vtkCellArray()
+
+        # Generate the points
+        for v in self.vertices:
+            pts.InsertNextPoint(v[0], v[1], v[2])
+
+        # Generate the triangle cells
+        for t in self.triangles:
+            triangle = vtk.vtkTriangle()
+            triangle.GetPointIds().SetId(0, t[0])
+            triangle.GetPointIds().SetId(1, t[1])
+            triangle.GetPointIds().SetId(2, t[2])
+            cells.InsertNextCell(triangle)
+
+        output.SetPoints(pts)
+        output.SetCells(vtk.VTK_TRIANGLE, cells)
+        return output
+
 
 class SurfaceGridGeometry(ProjectElementGeometry):
     """Contains spatial information of a 2D grid"""
@@ -113,6 +139,20 @@ class SurfaceGridGeometry(ProjectElementGeometry):
             )
         return True
 
+    def toVTK(self):
+        """Convert the 2D grid to a ``vtkStructuredGrid`` object."""
+        import vtk
+        from vtk.util import numpy_support as nps
+
+        output = vtk.vtkStructuredGrid()
+
+        # TODO: build!
+        # Build out all nodes in the mesh
+
+        # Add to output
+
+        return output
+
 
 class SurfaceElement(ProjectElement):
     """Contains mesh, data, textures, and options of a surface"""
@@ -131,3 +171,9 @@ class SurfaceElement(ProjectElement):
         choices=('surface',),
         default='surface'
     )
+
+    def toVTK(self):
+        """Convert the surface to a its appropriate VTK data object type."""
+        output = self.geometry.toVTK()
+        # TODO: handle textures
+        return output

--- a/omf/surface.py
+++ b/omf/surface.py
@@ -174,6 +174,17 @@ class SurfaceElement(ProjectElement):
 
     def toVTK(self):
         """Convert the surface to a its appropriate VTK data object type."""
+        from vtk.util import numpy_support as nps
+
         output = self.geometry.toVTK()
+
         # TODO: handle textures
+
+        # Now add point data:
+        for data in self.data:
+            arr = data.array.array
+            c = nps.numpy_to_vtk(num_array=arr)
+            c.SetName(data.name)
+            output.GetPointData().AddArray(c)
+
         return output

--- a/omf/surface.py
+++ b/omf/surface.py
@@ -64,12 +64,16 @@ class SurfaceGeometry(ProjectElementGeometry):
         pts.SetData(nps.numpy_to_vtk(self.vertices))
 
         # Generate the triangle cells
+        import time
+        start_time = time.time()
         for t in self.triangles:
+            # TODO: this desperately need optimizing
             triangle = vtk.vtkTriangle()
             triangle.GetPointIds().SetId(0, t[0])
             triangle.GetPointIds().SetId(1, t[1])
             triangle.GetPointIds().SetId(2, t[2])
             cells.InsertNextCell(triangle)
+        print("--- %s seconds ---" % (time.time() - start_time))
 
         output.SetPoints(pts)
         output.SetCells(vtk.VTK_TRIANGLE, cells)

--- a/omf/volume.py
+++ b/omf/volume.py
@@ -88,7 +88,7 @@ class VolumeGridGeometry(ProjectElementGeometry):
         ox, oy, oz = self.origin
 
         def checkOrientation():
-            if np.allclose(self.axis_u, (1,0,0)) and np.allclose(self.axis_v, (0,1,0)) and np.allclose(self.axis_w, (0,0,1)):
+            if np.allclose(self.axis_u, (1, 0, 0)) and np.allclose(self.axis_v, (0, 1, 0)) and np.allclose(self.axis_w, (0, 0, 1)):
                 return True
             return False
 
@@ -119,7 +119,7 @@ class VolumeGridGeometry(ProjectElementGeometry):
 
         # Build out all nodes in the mesh
         xx, yy, zz = np.meshgrid(x, y, z, indexing='ij')
-        points = np.stack( (xx.flatten(), yy.flatten(), zz.flatten()) ).T
+        points = np.stack((xx.flatten(), yy.flatten(), zz.flatten())).T
 
         # Rotate the points based on the axis orientations
         rmtx = rotationMatrix()
@@ -127,8 +127,8 @@ class VolumeGridGeometry(ProjectElementGeometry):
 
         # Convert points to vtk object
         pts = vtk.vtkPoints()
-        for r in points:
-            pts.InsertNextPoint(r[0], r[1], r[2])
+        pts.SetNumberOfPoints(len(points))
+        pts.SetData(nps.numpy_to_vtk(points))
         # Now build the output
         output.SetPoints(pts)
 

--- a/omf/volume.py
+++ b/omf/volume.py
@@ -62,6 +62,10 @@ class VolumeGridGeometry(ProjectElementGeometry):
         """Number of cells"""
         return len(self.tensor_u) * len(self.tensor_v) * len(self.tensor_w)
 
+    @property
+    def shape(self):
+        return ( len(self.tensor_u), len(self.tensor_v), len(self.tensor_w))
+
     @properties.validator
     def _validate_mesh(self):
         """Check if mesh content is built correctly"""
@@ -79,14 +83,54 @@ class VolumeGridGeometry(ProjectElementGeometry):
         import vtk
         from vtk.util import numpy_support as nps
 
-        # if axis orientations are standard then use a vtkRectilinearGrid
-        #- otherwise use a vtkStructuredGrid
+        self._validate_mesh()
+
+        ox, oy, oz = self.origin
+
+        def checkOrientation():
+            if np.allclose(self.axis_u, (1,0,0)) and np.allclose(self.axis_v, (0,1,0)) and np.allclose(self.axis_w, (0,0,1)):
+                return True
+            return False
+
+        def rotationMatrix():
+            # TODO: is this correct?
+            return np.array([self.axis_u, self.axis_v, self.axis_w])
+
+        # Make coordinates along each axis
+        x = ox + np.cumsum(self.tensor_u)
+        x = np.insert(x, 0, ox)
+        y = oy + np.cumsum(self.tensor_v)
+        y = np.insert(y, 0, oy)
+        z = oz + np.cumsum(self.tensor_w)
+        z = np.insert(z, 0, oz)
+
+        # If axis orientations are standard then use a vtkRectilinearGrid
+        if checkOrientation():
+            output = vtk.vtkRectilinearGrid()
+            output.SetDimensions(len(x), len(y), len(z)) # note this subtracts 1
+            output.SetXCoordinates(nps.numpy_to_vtk(num_array=x))
+            output.SetYCoordinates(nps.numpy_to_vtk(num_array=y))
+            output.SetZCoordinates(nps.numpy_to_vtk(num_array=z))
+            return output
+
+        # Otherwise use a vtkStructuredGrid
         output = vtk.vtkStructuredGrid()
+        output.SetDimensions(len(x), len(y), len(z)) # note this subtracts 1
 
-        # TODO: build!
         # Build out all nodes in the mesh
+        xx, yy, zz = np.meshgrid(x, y, z, indexing='ij')
+        points = np.stack( (xx.flatten(), yy.flatten(), zz.flatten()) ).T
 
-        # Add to output
+        # Rotate the points based on the axis orientations
+        rmtx = rotationMatrix()
+        points = points.dot(rmtx)
+
+        # Convert points to vtk object
+        pts = vtk.vtkPoints()
+        for r in points:
+            pts.InsertNextPoint(r[0], r[1], r[2])
+        # Now build the output
+        output.SetPoints(pts)
 
         return output
 
@@ -105,5 +149,14 @@ class VolumeElement(ProjectElement):
 
     def toVTK(self):
         """Convert the volume element to a VTK data object."""
+        from vtk.util import numpy_support as nps
         output = self.geometry.toVTK()
+        shp = self.geometry.shape
+        # Add data to output
+        for data in self.data:
+            arr = data.array.array
+            arr = np.reshape(arr, shp).flatten(order='F')
+            c = nps.numpy_to_vtk(num_array=arr, deep=True)
+            c.SetName(data.name)
+            output.GetCellData().AddArray(c)
         return output

--- a/omf/volume.py
+++ b/omf/volume.py
@@ -71,6 +71,25 @@ class VolumeGridGeometry(ProjectElementGeometry):
             raise ValueError('axis_u, axis_v, and axis_w must be orthogonal')
         return True
 
+    def toVTK(self):
+        """Convert the 3D gridded volume to a ``vtkStructuredGrid``
+        (or a ``vtkRectilinearGrid`` when apprropriate) object contatining the
+        2D surface.
+        """
+        import vtk
+        from vtk.util import numpy_support as nps
+
+        # if axis orientations are standard then use a vtkRectilinearGrid
+        #- otherwise use a vtkStructuredGrid
+        output = vtk.vtkStructuredGrid()
+
+        # TODO: build!
+        # Build out all nodes in the mesh
+
+        # Add to output
+
+        return output
+
 
 class VolumeElement(ProjectElement):
     """Contains mesh, data, and options of a volume"""
@@ -83,3 +102,8 @@ class VolumeElement(ProjectElement):
         choices=('volume',),
         default='volume'
     )
+
+    def toVTK(self):
+        """Convert the volume element to a VTK data object."""
+        output = self.geometry.toVTK()
+        return output

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,5 @@
 sphinx
 nose-cov
 pylint
+vtk
 -e .


### PR DESCRIPTION
**Synopsis:** Add new VTK conversion methods to project elements.

Please consider this branch experimental in its current state. I want to get a pull request going to discuss whether these features are appropriate to have in the `omf` package.

The [Visualization Toolkit (VTK)](https://www.vtk.org) is a cross-platform, open-source library for data processing and visualization built on C++ and wrapped for use in Python. VTK provides a framework for scalable visualizations and powers many open source visualization software platforms like [ParaView](https://www.paraview.org).  I believe that adding VTK support to `omf` will enable geoscientists to directly pair the Open Mining Format with their VTK powered processing or visualization routines/software and provide a set of functionality that will work out of the box. 

I initially began writing these conversion methods for the [*PVGeo*](https://github.com/OpenGeoVis/PVGeo) repository to build an OMF project file reader for ParaView. After working a bit with the OMF package and file format, I began to realize I needed a means to directly convert the project elements to VTK data objects to use in some of my other processing routines outside of ParaView. Rather than importing an external package to call various conversions methods for each element’s type, I thought it’d be best to allow each element to convert itself within `omf` directly. Thus providing stable conversion methods for each `ProjectElement` and a place to start for using `omf` in VTK processing routines without the need for static file conversions.

## New Features:
For every subclass of the `ProjectElement` (or `ProjectElementGeometry` when appropriate), I have added a method called `toVTK()` which will convert the element to a VTK data object that corresponds to its features/topology. This allows for users to iterate over a `Project`’s elements list and directly convert that element to a VTK data object like the example below:

### Example:
```py
>>> import omf

>>> # Read the test file in the repo's assets
>>> reader = omf.OMFReader('test_file.omf')
>>> project = reader.get_project()

>>> # Iterate over the elements and add converted VTK object to dictionary:
>>> data = dict()
>>> for e in project.elements:
>>>     data[e.name] = e.toVTK()
```

Now we have a dictionary of VTK data objects to use in VTK processing/visualization routines:
```py
>>> data
{u'Basement': (vtkCommonDataModelPython.vtkUnstructuredGrid)0x10726e598,
 u'Block Model': (vtkCommonDataModelPython.vtkRectilinearGrid)0x10726e738,
 u'Cover': (vtkCommonDataModelPython.vtkUnstructuredGrid)0x10726e3f8,
 u'Dacite': (vtkCommonDataModelPython.vtkUnstructuredGrid)0x10726e530,
 u'Early Diorite': (vtkCommonDataModelPython.vtkUnstructuredGrid)0x10726e600,
 u'Intermineral diorite': (vtkCommonDataModelPython.vtkUnstructuredGrid)0x10726e668,
 u'Topography': (vtkCommonDataModelPython.vtkUnstructuredGrid)0x10726e4c8,
 u'collar': (vtkCommonDataModelPython.vtkPolyData)0x10726e258,
 u'wolfpass_WP_assay': (vtkCommonDataModelPython.vtkPolyData)0x10726e6d0}
```

Directly convert/check a single element:
```py
>>> el = project.elements[-1] # the `Block Model` element
>>> el.name
Block Model
>>> grid = el.toVTK()
>>> grid
(vtkCommonDataModelPython.vtkRectilinearGrid)0x10726e870
>>> assert(grid.GetNumberOfCells() == el.geometry.num_cells)
>>> assert(grid.GetNumberOfPoints() == el.geometry.num_nodes)
```




## Concerns
I realize that a goal of `omf` is likely to remain a lightweight tool and provide a simple API so that users can integrate the Open Mining Format with their python powered processing software. In my experience, VTK can be cumbersome to install on non-Unix operating systems and thus it might make `omf` less lightweight out of the box. For this reason, I have kept all `vtk` imports internally within the `toVTK()` methods to ensure that the package can be used entirely without VTK in the active environment.

I imagine that `omf` was built with the idea that functionality to use the `ProjectElement`s would be implemented in external libraries, but I am making a proposition that VTK is widely used enough that a standard means of generating VTK data objects should be included with the OMF package.


## Progress:
- [ ] Line Set
	- [x] Generate `vtkPloyData` with CELL data attributes
	- [ ] If subtype is a borehole: make cylinders instead of lines.

- [ ] Point Set
	- [x] Generate `vtkPloyData` with POINT data attributes
	- [ ] Handle textures

- [ ] Surface
	- [x] Generate `vtkUnstructuredGrid` for `SurfaceGeometry`
	- [ ] `SurfaceGridGeometry`:
		- [ ] `vtkStructuredGrid` if axis are not default XYZ cartesian
		- [ ] `vtkRectilinearGrid` if axis is aligned with Cartesian system
	- [x] Add POINT data attributes
	- [ ] Handle textures

- [x] Volume
	- [x] `VolumeGridGeometry`
		- [x] `vtkStructuredGrid` if axis are not default XYZ cartesian
		- [x] `vtkRectilinearGrid` if axis is aligned with Cartesian system
	- [x] Add CELL data attributes

# PVGeo
I also want to include here what this enables me to build in the [*PVGeo*](https://github.com/OpenGeoVis/PVGeo) package. By providing these methods to generate VTK data objects for each element type, I have created a reader for ParaView that will directly read an OMF project file, allow a user to select the elements they want to load, then have these elements directly rendered by ParaView:

[**EXAMPLE SCENE**](http://viewer.pvgeo.org/?fileURL=https://dl.dropbox.com/s/b55sx8h0rjmybzl/omf-test.vtkjs?dl=0)

## What this looks like within ParaView:
<img width="1155" alt="screen shot 2018-07-16 at 12 26 23 pm" src="https://user-images.githubusercontent.com/22067021/42776185-8243246e-88f3-11e8-93cb-eefd71ebdf00.png">
<img width="1169" alt="screen shot 2018-07-16 at 12 19 57 pm" src="https://user-images.githubusercontent.com/22067021/42776189-85bdd5d0-88f3-11e8-8330-6559873db31e.png">
