### PR TITLE
[GH-45] contribution guidelines and code of conduct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,96 @@
+# Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+*$py.class
 
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
 *.egg-info/
+.installed.cfg
+*.egg
 
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
 docs/_build/
+docs/_themes/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+Untitled*.ipynb
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+
+.DS_Store
+deps/
+
+cover/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,111 @@
+# Contributing to the Open Mining Format
+
+There are many ways to contribute to OMF:
+- [**Become a member** of GMG Group](#membership)
+- [**Raise issues** for any questions/feedback/problems you have](#issues)
+- [**Write code** to directly move the format forward](#code)
+- [**Provide documentation** and examples](#docs)
+
+## <a name="membership"></a>High-level involvement through Global Mining Guidelines Group
+
+The Open Mining Format has been created through the Data Exchange for
+Mine Software Project under the
+[Data Access and Usage Working Group](https://gmggroup.org/groups/data-access-and-usage-dau/).
+This sub-committee is involved with all aspects of the success of OMF,
+including industry engagement and organization, technical design and
+development, and outreach and marketing.
+[Learn more about the GMG Group](https://gmggroup.org/) or
+[become a member](https://gmggroup.org/about-us/membership/)
+
+## <a name="issues"></a>Raising questions, feedback, problems
+
+Given the *open* nature of OMF, all technical conversations and
+development happen, here, on GitHub, visible to everyone. To
+participate, all you need is a [free GitHub account](https://github.com/join);
+there is no requirement to be a member of GMG Group or even part of
+the mining community.
+
+Any questions/feedback/problems should be raised as
+[issues](https://github.com/gmggroup/omf/issues). You may comment on
+existing, relevant issues or
+[create a new issue](https://github.com/gmggroup/omf/issues/new). There
+is no restriction on what issues are "supposed to" look like; this is
+the place for anyone to voice anything about OMF. Examples include:
+- detailed technical questions around implementation
+- problems encountered when attempting to support OMF
+- confusion around the documentation
+- feature requests for the format
+- questions around the high-level goal of an open standard
+- suggestions around non-technical aspects, such as marketing and engagement
+- etc!
+
+If the question is non-technical, follow up may happen outside of
+GitHub, but this is the place to start.
+
+And, please, read and follow our [Code of Conduct](code_of_conduct.md).
+
+## <a name="code"></a>Contributing to code development
+
+Anyone can submit pull requests to the OMF repository. Preferably these
+are related to an
+[existing bug](https://github.com/gmggroup/omf/issues?q=is%3Aopen+is%3Aissue+label%3Abug)
+or a feature included in an
+[upcoming milestone](https://github.com/gmggroup/omf/milestones).
+[Low-hanging-fruit issues](https://github.com/gmggroup/omf/issues?q=is%3Aopen+is%3Aissue+label%3A%22%3Aarrow_down%3A+%3Agreen_apple%3A%22)
+are great for first-time contributors. If the solution to the issue is
+unclear, please follow up and ask for clarification; if nothing else,
+it's useful to know what people are working on. If your pull request
+does not have an existing issue, consider [creating an issue](#issues)
+first, just to add context and promote discussion.
+
+When working on your contribution, you may
+[fork](https://help.github.com/en/articles/fork-a-repo) the OMF repo to
+your personal or company GitHub organization and develop there.
+Alternatively, if you are interested in being identified as a contributor
+to the [GMG Group GitHub organization](https://github.com/gmggroup),
+reach out to [fwkoch](https://github.com/fwkoch) (note: this is
+distinct from [GMG Group membership](#membership)). Once you are
+a contributor on GitHub, you may
+[create feature branches](https://help.github.com/en/articles/creating-and-deleting-branches-within-your-repository)
+directly in the GMG Group OMF repository.
+
+When creating a branch, consider naming it in the format
+`GH-##/human_readable_description`, where "##" is the related
+issue number. Strive for as much inter-linking as possible of pull
+requests, issues numbers, commits, etc.
+
+When submitting a pull request, please base off the `dev` branch.
+Contributions will be collected here, then version-bumped and deployed
+via pull request from `dev` to `master` as appropriate.
+
+Finally, everyone appreciates unit tests, code documentation, consistent
+style, and please always read and follow our
+[Code of Conduct](code_of_conduct.md).
+
+### <a name="docs"></a>Contributing documentation and examples
+
+The most useful contributions for the success of OMF are documentation
+and examples that can be shared with everyone. To use the format,
+people must understand the format. Documentation comes in many forms;
+it can include:
+- Technical documentation of the code and API
+- Description of how the API relates to real objects
+- Workflows describing specific implementations of OMF in prose, code,
+  or screenshots
+- Example OMF files, ideally along side source files of other formats
+  and description of the import/export process.
+- etc!
+
+Contributing documentation and examples is also more flexible than
+code contributions. Documentation hosted on
+[readthedocs](https://omf.readthedocs.io/en/stable/) is directly built
+from the GitHub repository, so you may contribute documentation there
+by submitting a PR. However, it is also entirely valid to
+[create a new issue](https://github.com/gmggroup/omf/issues/new) and
+attach any files or text you have there. Somebody will take those
+submissions and put them in the appropriate place.
+
+By documenting and highlighting diverse, successful OMF use-cases, we
+are able to demonstrate early industry engagement, and this will promote
+further adoption.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to the Open Mining Format
 
 There are many ways to contribute to OMF:
-- [**Become a member** of GMG Group](#membership)
+- [**Become a member** of GMG](#membership)
 - [**Raise issues** for any questions/feedback/problems you have](#issues)
 - [**Write code** to directly move the format forward](#code)
 - [**Provide documentation** and examples](#docs)
@@ -14,7 +14,7 @@ Mine Software Project under the
 This sub-committee is involved with all aspects of the success of OMF,
 including industry engagement and organization, technical design and
 development, and outreach and marketing.
-[Learn more about the GMG Group](https://gmggroup.org/) or
+[Learn more about GMG](https://gmggroup.org/) or
 [become a member](https://gmggroup.org/about-us/membership/)
 
 ## <a name="issues"></a>Raising questions, feedback, problems
@@ -22,7 +22,7 @@ development, and outreach and marketing.
 Given the *open* nature of OMF, all technical conversations and
 development happen, here, on GitHub, visible to everyone. To
 participate, all you need is a [free GitHub account](https://github.com/join);
-there is no requirement to be a member of GMG Group or even part of
+there is no requirement to be a member of GMG or even part of
 the mining community.
 
 Any questions/feedback/problems should be raised as
@@ -63,12 +63,12 @@ When working on your contribution, you may
 [fork](https://help.github.com/en/articles/fork-a-repo) the OMF repo to
 your personal or company GitHub organization and develop there.
 Alternatively, if you are interested in being identified as a contributor
-to the [GMG Group GitHub organization](https://github.com/gmggroup),
-reach out to [*info@gmggroup.org*](mailto:info@gmggroup.org) (note: this
-is distinct from [GMG Group membership](#membership)). Once you are
-a contributor on GitHub, you may
+to the [GMG GitHub organization](https://github.com/gmggroup),
+reach out to [David Sanguinetti](mailto:dsanguinetti@gmggroup.org),
+the program manager at GMG (note: this is distinct from
+[GMG membership](#membership)). Once you are a contributor on GitHub, you may
 [create feature branches](https://help.github.com/en/articles/creating-and-deleting-branches-within-your-repository)
-directly in the GMG Group OMF repository.
+directly in the GMG OMF repository.
 
 When creating a branch, consider naming it in the format
 `GH-##/human_readable_description`, where "##" is the related

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Any questions/feedback/problems should be raised as
 existing, relevant issues or
 [create a new issue](https://github.com/gmggroup/omf/issues/new). There
 is no restriction on what issues are "supposed to" look like; this is
-the place for anyone to voice anything about OMF. Examples include:
+a place for anyone to voice anything about OMF. Examples include:
 - detailed technical questions around implementation
 - problems encountered when attempting to support OMF
 - confusion around the documentation
@@ -40,9 +40,10 @@ the place for anyone to voice anything about OMF. Examples include:
 - etc!
 
 If the question is non-technical, follow up may happen outside of
-GitHub, but this is the place to start.
+GitHub, but this is a place to start.
 
-And, please, read and follow our [Code of Conduct](code_of_conduct.md).
+To ensure the OMF community remains welcoming and productive, please read and
+follow our [Code of Conduct](code_of_conduct.md).
 
 ## <a name="code"></a>Contributing to code development
 
@@ -63,8 +64,8 @@ When working on your contribution, you may
 your personal or company GitHub organization and develop there.
 Alternatively, if you are interested in being identified as a contributor
 to the [GMG Group GitHub organization](https://github.com/gmggroup),
-reach out to [fwkoch](https://github.com/fwkoch) (note: this is
-distinct from [GMG Group membership](#membership)). Once you are
+reach out to [*info@gmggroup.org*](mailto:info@gmggroup.org) (note: this
+is distinct from [GMG Group membership](#membership)). Once you are
 a contributor on GitHub, you may
 [create feature branches](https://help.github.com/en/articles/creating-and-deleting-branches-within-your-repository)
 directly in the GMG Group OMF repository.
@@ -78,9 +79,9 @@ When submitting a pull request, please base off the `dev` branch.
 Contributions will be collected here, then version-bumped and deployed
 via pull request from `dev` to `master` as appropriate.
 
-Finally, everyone appreciates unit tests, code documentation, consistent
-style, and please always read and follow our
-[Code of Conduct](code_of_conduct.md).
+Finally, everyone appreciates unit tests, code documentation, and
+consistent style. And, to ensure the OMF community remains welcoming
+and productive, read and follow our [Code of Conduct](code_of_conduct.md).
 
 ### <a name="docs"></a>Contributing documentation and examples
 

--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -1,5 +1,10 @@
 # Open Mining Format Code of Conduct
 
+- [Overview](#Overview)
+- [Principles](#Principles)
+- [Reporting](#Reporting)
+- [Antitrust Compliance](#Antitrust-Compliance)
+
 ## Overview
 
 When attempting to overcome challenges alone, the obstacles can seem

--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -5,7 +5,7 @@
 When attempting to overcome challenges alone, the obstacles can seem
 monumental. When approached together, however, anything is possible.
 
-The GMG group is a community of mining companies, OEMs, OTMs, research
+The GMG Group is a community of mining companies, OEMs, OTMs, research
 organizations, and consultants from around the world who recognize that
 innovation does not happen in silos. Together, this diverse community
 addresses common challenges and creates tangible deliverables,

--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -1,0 +1,107 @@
+# Open Mining Format Code of Conduct
+
+## Overview
+
+When attempting to overcome challenges alone, the obstacles can seem
+monumental. When approached together, however, anything is possible.
+
+The GMG group is a community of mining companies, OEMs, OTMs, research
+organizations, and consultants from around the world who recognize that
+innovation does not happen in silos. Together, this diverse community
+addresses common challenges and creates tangible deliverables,
+enabling a productive, safe, and sustainable future for mining.
+
+A diverse community brings diverse ideas and perspectives to complex
+problems; this is paramount to the success of any open source project,
+including OMF. However, conflicting viewpoints and disagreement can
+quickly escalate into harassment and aggression when amplified by
+misunderstanding, miscommunication, and taking disagreement personally.
+
+## Principles
+
+By embracing the following principles, guidelines, and actions to
+follow or avoid, you will help us make the OMF community welcoming
+and productive.
+
+- **Be friendly and patient.**
+
+- **Be welcoming.** We strive to be a community that welcomes and
+  supports people of all backgrounds and identities. This includes,
+  but is not limited to, members of any race, ethnicity, culture,
+  national origin, color, immigration status, social and economic
+  class, educational level, sex, sexual orientation, gender identity
+  and expression, age, physical appearance, family status,
+  technological or professional choices, academic discipline, religion,
+  mental ability, and physical ability.
+
+- **Be considerate.** Your work will be used by other people, and you
+  in turn will depend on the work of others. Any decision you take will
+  affect users and colleagues, and you should take those consequences
+  into account when making decisions. Remember that we're a world-wide
+  community. You may be communicating with someone with a different
+  primary language or cultural background.
+
+- **Be respectful.** Not all of us will agree all the time, but
+  disagreement is no excuse for poor behavior or poor manners. We might
+  all experience some frustration now and then, but we cannot allow that
+  frustration to turn into a personal attack. It’s important to remember
+  that a community where people feel uncomfortable or threatened is not
+  a productive one.
+
+- **Be careful in the words that you choose.** Be kind to others. Do not
+  insult or put down other community members. Harassment and other
+  exclusionary behavior are not acceptable. This includes, but is not
+  limited to:
+    - Violent threats or violent language directed against another
+      person
+    - Discriminatory jokes and language
+    - Posting sexually explicit or violent material
+    - Posting (or threatening to post) other people's personally
+      identifying information ("doxing")
+    - Personal insults, especially those using racist or sexist terms
+    - Unwelcome sexual attention
+    - Advocating for, or encouraging, any of the above behavior
+    - Repeated harassment of others. In general, if someone asks you to
+      stop, then stop
+
+- **Moderate your expectations.** Please respect that community members
+  choose how they spend their time in the project. A thoughtful question
+  about your expectations is preferable to demands for another person's
+  time.
+
+- **When we disagree, try to understand why.** Disagreements, both
+  social and technical, happen all the time and the OMF community is no
+  exception. Try to understand where others are coming from, as seeing
+  a question from their viewpoint may help find a new path forward. And
+  don’t forget that it is human to err: blaming each other doesn’t get
+  us anywhere, while we can learn from mistakes to find better
+  solutions.
+
+- **A simple apology can go a long way.** It can often de-escalate a
+  situation, and telling someone that you are sorry is an act of empathy
+  that doesn’t automatically imply an admission of guilt.
+
+## Reporting
+
+As a member of our community, you are also a steward of these values.
+Not all problems need to be resolved via formal processes, and often a
+quick, friendly but clear word in an online message or in person can
+help resolve a misunderstanding and de-escalate things.
+
+An informal enforcement of this process may be inadequate if there is
+urgency, risk to someone, no one is comfortable speaking out, the
+offender is unresponsive, etc. In that case, please file a report
+by emailing [*info@gmggroup.org*](mailto:info@gmggroup.org). This will
+be kept anonymous and action will be taken.
+
+#### Attribution
+
+This document is modified from other codes of conduct, courtesy of the
+[*Speak Up!*](http://web.archive.org/web/20141109123859/http://speakup.io/coc.html),
+[*Django*](https://www.djangoproject.com/conduct), and
+[*Jupyter*](https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md)
+Projects.
+
+All content on this page is licensed under a
+[*Creative Commons Attribution*](http://creativecommons.org/licenses/by/3.0/)
+license.

--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -94,6 +94,12 @@ offender is unresponsive, etc. In that case, please file a report
 by emailing [*info@gmggroup.org*](mailto:info@gmggroup.org). This will
 be kept anonymous and action will be taken.
 
+## Antitrust Compliance
+
+All participants in GMG Group activity must comply with applicable
+antitrust laws. Please refer to the detailed guidelines provided on the
+[GMG Group governance page](https://gmggroup.org/about-us/governance/).
+
 #### Attribution
 
 This document is modified from other codes of conduct, courtesy of the

--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -5,10 +5,11 @@
 When attempting to overcome challenges alone, the obstacles can seem
 monumental. When approached together, however, anything is possible.
 
-The GMG Group is a community of mining companies, OEMs, OTMs, research
-organizations, and consultants from around the world who recognize that
-innovation does not happen in silos. Together, this diverse community
-addresses common challenges and creates tangible deliverables,
+The Global Mining Guidelines Group (GMG) is a community of mining
+companies, OEMs, OTMs, research organizations, and consultants
+from around the world who recognize that innovation does not
+happen in silos. Together, this diverse community addresses
+common challenges and creates tangible deliverables,
 enabling a productive, safe, and sustainable future for mining.
 
 A diverse community brings diverse ideas and perspectives to complex
@@ -91,14 +92,15 @@ help resolve a misunderstanding and de-escalate things.
 An informal enforcement of this process may be inadequate if there is
 urgency, risk to someone, no one is comfortable speaking out, the
 offender is unresponsive, etc. In that case, please file a report
-by emailing [*info@gmggroup.org*](mailto:info@gmggroup.org). This will
-be kept anonymous and action will be taken.
+by emailing [David Sanguinetti](mailto:dsanguinetti@gmggroup.org),
+the program manager at GMG. Reports will be kept anonymous and action
+will be taken.
 
 ## Antitrust Compliance
 
-All participants in GMG Group activity must comply with applicable
+All participants in GMG activity must comply with applicable
 antitrust laws. Please refer to the detailed guidelines provided on the
-[GMG Group governance page](https://gmggroup.org/about-us/governance/).
+[GMG governance page](https://gmggroup.org/about-us/governance/).
 
 #### Attribution
 


### PR DESCRIPTION
Before merging, we should identify a better contact email for the code of conduct than info@gmggroup.org

See #45 