### PR TITLE
[GH-64] Build on properties.extras.HasUid

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,11 +2,11 @@ omf
 ***
 
 .. image:: https://img.shields.io/pypi/v/omf.svg
-    :target: https://pypi.python.org/pypi/omf
+    :target: https://pypi.org/project/omf/
     :alt: Latest PyPI version
 
 .. image:: https://readthedocs.org/projects/omf/badge/?version=stable
-    :target: http://omf.readthedocs.io/en/latest/
+    :target: https://omf.readthedocs.io/en/latest/
     :alt: Documentation
 
 .. image:: https://img.shields.io/badge/license-MIT-blue.svg
@@ -86,7 +86,7 @@ Or from `github <https://github.com/gmggroup/omf>`_:
     git clone https://github.com/gmggroup/omf.git
     cd omf
     pip install -e .
-    
+
 
 3D Visualization
 ----------------
@@ -95,4 +95,4 @@ To easily visualize OMF project files and data objects in a pure Python environm
 
 .. _OMF-VTK: https://github.com/OpenGeoVis/omfvtk
 
-.. _vtkInterface: https://github.com/akaszynski/vtki
+.. _vtkInterface: https://github.com/vtkiorg/vtki

--- a/omf/data.py
+++ b/omf/data.py
@@ -16,7 +16,7 @@ class ScalarArray(UidModel):
     array = properties.Array(
         'Shared Scalar Array',
         serializer=array_serializer,
-        deserializer=array_deserializer(('*',))
+        deserializer=array_deserializer(('*',)),
     )
 
     def __init__(self, array=None, **kwargs):
@@ -36,7 +36,7 @@ class Vector2Array(ScalarArray):
     array = properties.Vector2Array(
         'Shared Vector2 Array',
         serializer=array_serializer,
-        deserializer=array_deserializer(('*', 2))
+        deserializer=array_deserializer(('*', 2)),
     )
 
 
@@ -45,7 +45,7 @@ class Vector3Array(ScalarArray):
     array = properties.Vector3Array(
         'Shared Vector3 Array',
         serializer=array_serializer,
-        deserializer=array_deserializer(('*', 3))
+        deserializer=array_deserializer(('*', 3)),
     )
 
 
@@ -56,7 +56,7 @@ class Int2Array(ScalarArray):
         dtype=int,
         shape=('*', 2),
         serializer=array_serializer,
-        deserializer=array_deserializer(('*', 2))
+        deserializer=array_deserializer(('*', 2)),
     )
 
 
@@ -67,7 +67,7 @@ class Int3Array(ScalarArray):
         dtype=int,
         shape=('*', 3),
         serializer=array_serializer,
-        deserializer=array_deserializer(('*', 3))
+        deserializer=array_deserializer(('*', 3)),
     )
 
 
@@ -102,7 +102,7 @@ class ScalarColormap(ContentModel):
     """Length-128 color gradient with min/max values, used with ScalarData"""
     gradient = properties.Instance(
         'length-128 ColorArray defining the gradient',
-        ColorArray
+        ColorArray,
     )
     limits = properties.List(
         'Data range associated with the gradient',
@@ -145,12 +145,12 @@ class ScalarData(ProjectElementData):
     """Data array with scalar values"""
     array = properties.Instance(
         'scalar values at locations on a mesh (see location parameter)',
-        ScalarArray
+        ScalarArray,
     )
     colormap = properties.Instance(
         'colormap associated with the data',
         ScalarColormap,
-        required=False
+        required=False,
     )
 
 
@@ -158,7 +158,7 @@ class Vector3Data(ProjectElementData):
     """Data array with 3D vectors"""
     array = properties.Instance(
         '3D vectors at locations on a mesh (see location parameter)',
-        Vector3Array
+        Vector3Array,
     )
 
 
@@ -166,7 +166,7 @@ class Vector2Data(ProjectElementData):
     """Data array with 2D vectors"""
     array = properties.Instance(
         '2D vectors at locations on a mesh (see location parameter)',
-        Vector2Array
+        Vector2Array,
     )
 
 
@@ -185,7 +185,7 @@ class ColorData(ProjectElementData):
         'RGB color values at locations on a mesh (see location parameter)',
         props=(
             Int3Array,
-            ColorArray
+            ColorArray,
         )
     )
 
@@ -200,7 +200,7 @@ class StringData(ProjectElementData):
     """Data array with text entries"""
     array = properties.Instance(
         'text at locations on a mesh (see location parameter)',
-        StringArray
+        StringArray,
     )
 
 
@@ -208,12 +208,12 @@ class DateTimeData(ProjectElementData):
     """Data array with DateTime entries"""
     array = properties.Instance(
         'datetimes at locations on a mesh (see location parameter)',
-        DateTimeArray
+        DateTimeArray,
     )
     colormap = properties.Instance(
         'colormap associated with the data',
         DateTimeColormap,
-        required=False
+        required=False,
     )
 
 
@@ -225,7 +225,7 @@ class Legend(ContentModel):
             ColorArray,
             DateTimeArray,
             StringArray,
-            ScalarArray
+            ScalarArray,
         )
     )
 
@@ -234,7 +234,7 @@ class MappedData(ProjectElementData):
     """Data array of indices linked to legend values or -1 for no data"""
     array = properties.Instance(
         'indices into 1 or more legends for locations on a mesh',
-        ScalarArray
+        ScalarArray,
     )
     legends = properties.List(
         'legends into which the indices map',

--- a/omf/fileio.py
+++ b/omf/fileio.py
@@ -148,7 +148,7 @@ class OMFReader(object):
                 if prop in element:
                     del element[prop]
             filtered_json[uid] = element
-        project_json.update({'__root__': self._uid})
+        filtered_json.update({'__root__': self._uid})
         project = UidModel.deserialize(
             value=filtered_json,
             trusted=True,

--- a/omf/fileio.py
+++ b/omf/fileio.py
@@ -127,7 +127,7 @@ class OMFReader(object):
             project_elements['elements'] = filtered_elements
 
         project_json.update({'__root__': self._uid})
-        UidModel._INSTANCES = {}
+        UidModel._INSTANCES = {}                                               #pylint: disable=protected-access
         project = UidModel.deserialize(
             value=project_json,
             trusted=True,
@@ -150,7 +150,7 @@ class OMFReader(object):
                     del element[prop]
             filtered_json[uid] = element
         filtered_json.update({'__root__': self._uid})
-        UidModel._INSTANCES = {}
+        UidModel._INSTANCES = {}                                               #pylint: disable=protected-access
         project = UidModel.deserialize(
             value=filtered_json,
             trusted=True,

--- a/omf/fileio.py
+++ b/omf/fileio.py
@@ -50,6 +50,7 @@ class OMFWriter(object):
         with open(fname, 'wb') as fopen:
             self.initialize_header(fopen, project.uid)
             self.project_json = project.serialize(open_file=fopen)
+            self.project_json.pop('__root__')
             self.update_header(fopen)
             fopen.write(json.dumps(self.project_json).encode('utf-8'))
 
@@ -69,7 +70,7 @@ class OMFWriter(object):
         fopen.write(
             struct.pack('<32s', COMPATIBILITY_VERSION.ljust(32, b'\x00'))
         )
-        fopen.write(struct.pack('<16s', uid.bytes))
+        fopen.write(struct.pack('<16s', uuid.UUID(uid).bytes))
         fopen.seek(8, 1)
 
     @staticmethod
@@ -125,9 +126,12 @@ class OMFReader(object):
                                  if uid in element_uids]
             project_elements['elements'] = filtered_elements
 
-        project = UidModel.deserialize(uid=self._uid,
-                                       registry=project_json,
-                                       open_file=self._fopen)
+        project_json.update({'__root__': self._uid})
+        project = UidModel.deserialize(
+            value=project_json,
+            trusted=True,
+            open_file=self._fopen,
+        )
         return project
 
     def get_project_overview(self):
@@ -144,9 +148,12 @@ class OMFReader(object):
                 if prop in element:
                     del element[prop]
             filtered_json[uid] = element
-        project = UidModel.deserialize(uid=self._uid,
-                                       registry=filtered_json,
-                                       open_file=self._fopen)
+        project_json.update({'__root__': self._uid})
+        project = UidModel.deserialize(
+            value=filtered_json,
+            trusted=True,
+            open_file=self._fopen,
+        )
         return project
 
     def read_header(self):

--- a/omf/fileio.py
+++ b/omf/fileio.py
@@ -127,6 +127,7 @@ class OMFReader(object):
             project_elements['elements'] = filtered_elements
 
         project_json.update({'__root__': self._uid})
+        UidModel._INSTANCES = {}
         project = UidModel.deserialize(
             value=project_json,
             trusted=True,
@@ -149,6 +150,7 @@ class OMFReader(object):
                     del element[prop]
             filtered_json[uid] = element
         filtered_json.update({'__root__': self._uid})
+        UidModel._INSTANCES = {}
         project = UidModel.deserialize(
             value=filtered_json,
             trusted=True,

--- a/omf/lineset.py
+++ b/omf/lineset.py
@@ -15,11 +15,11 @@ class LineSetGeometry(ProjectElementGeometry):
     """Contains spatial information of a line set"""
     vertices = properties.Instance(
         'Spatial coordinates of line vertices relative to line set origin',
-        Vector3Array
+        Vector3Array,
     )
     segments = properties.Instance(
         'Endpoint vertex indices of line segments',
-        Int2Array
+        Int2Array,
     )
 
     _valid_locations = ('vertices', 'segments')
@@ -54,10 +54,10 @@ class LineSetElement(ProjectElement):
     """Contains mesh, data, and options of a line set"""
     geometry = properties.Instance(
         'Structure of the line element',
-        instance_class=LineSetGeometry
+        instance_class=LineSetGeometry,
     )
     subtype = properties.StringChoice(
         'Category of LineSet',
         choices=('line', 'borehole'),
-        default='line'
+        default='line',
     )

--- a/omf/pointset.py
+++ b/omf/pointset.py
@@ -15,7 +15,7 @@ class PointSetGeometry(ProjectElementGeometry):
     """Contains spatial information of a point set"""
     vertices = properties.Instance(
         'Spatial coordinates of points relative to point set origin',
-        Vector3Array
+        Vector3Array,
     )
 
     _valid_locations = ('vertices',)
@@ -39,7 +39,7 @@ class PointSetElement(ProjectElement):
     """Contains mesh, data, textures, and options of a point set"""
     geometry = properties.Instance(
         'Structure of the point set element',
-        instance_class=PointSetGeometry
+        instance_class=PointSetGeometry,
     )
     textures = properties.List(
         'Images mapped on the element',
@@ -50,5 +50,5 @@ class PointSetElement(ProjectElement):
     subtype = properties.StringChoice(
         'Category of PointSet',
         choices=('point', 'collar', 'blasthole'),
-        default='point'
+        default='point',
     )

--- a/omf/surface.py
+++ b/omf/surface.py
@@ -16,11 +16,11 @@ class SurfaceGeometry(ProjectElementGeometry):
     """Contains spatial information about a triangulated surface"""
     vertices = properties.Instance(
         'Spatial coordinates of vertices relative to surface origin',
-        Vector3Array
+        Vector3Array,
     )
     triangles = properties.Instance(
         'Vertex indices of surface triangles',
-        Int3Array
+        Int3Array,
     )
 
     _valid_locations = ('vertices', 'faces')
@@ -55,27 +55,27 @@ class SurfaceGridGeometry(ProjectElementGeometry):
     tensor_u = properties.Array(
         'Grid cell widths, u-direction',
         shape=('*',),
-        dtype=float
+        dtype=float,
     )
     tensor_v = properties.Array(
         'Grid cell widths, v-direction',
         shape=('*',),
-        dtype=float
+        dtype=float,
     )
     axis_u = properties.Vector3(
         'Vector orientation of u-direction',
         default='X',
-        length=1
+        length=1,
     )
     axis_v = properties.Vector3(
         'Vector orientation of v-direction',
         default='Y',
-        length=1
+        length=1,
     )
     offset_w = properties.Instance(
         'Node offset',
         ScalarArray,
-        required=False
+        required=False,
     )
 
     _valid_locations = ('vertices', 'faces')
@@ -118,7 +118,10 @@ class SurfaceElement(ProjectElement):
     """Contains mesh, data, textures, and options of a surface"""
     geometry = properties.Union(
         'Structure of the surface element',
-        props=(SurfaceGeometry, SurfaceGridGeometry)
+        props=(
+            SurfaceGridGeometry,
+            SurfaceGeometry,
+        ),
     )
     textures = properties.List(
         'Images mapped on the surface element',
@@ -129,5 +132,5 @@ class SurfaceElement(ProjectElement):
     subtype = properties.StringChoice(
         'Category of Surface',
         choices=('surface',),
-        default='surface'
+        default='surface',
     )

--- a/omf/texture.py
+++ b/omf/texture.py
@@ -14,18 +14,18 @@ class ImageTexture(ContentModel):
     """Contains an image that can be mapped to a point set or surface"""
     origin = properties.Vector3(
         'Origin point of the texture',
-        default=[0., 0., 0.]
+        default=[0., 0., 0.],
     )
     axis_u = properties.Vector3(
         'Vector corresponding to the image x-axis',
-        default='X'
+        default='X',
     )
     axis_v = properties.Vector3(
         'Vector corresponding to the image y-axis',
-        default='Y'
+        default='Y',
     )
     image = properties.ImagePNG(
         'PNG image file',
         serializer=png_serializer,
-        deserializer=png_deserializer
+        deserializer=png_deserializer,
     )

--- a/omf/volume.py
+++ b/omf/volume.py
@@ -15,32 +15,32 @@ class VolumeGridGeometry(ProjectElementGeometry):
     tensor_u = properties.Array(
         'Tensor cell widths, u-direction',
         shape=('*',),
-        dtype=float
+        dtype=float,
     )
     tensor_v = properties.Array(
         'Tensor cell widths, v-direction',
         shape=('*',),
-        dtype=float
+        dtype=float,
     )
     tensor_w = properties.Array(
         'Tensor cell widths, w-direction',
         shape=('*',),
-        dtype=float
+        dtype=float,
     )
     axis_u = properties.Vector3(
         'Vector orientation of u-direction',
         default='X',
-        length=1
+        length=1,
     )
     axis_v = properties.Vector3(
         'Vector orientation of v-direction',
         default='Y',
-        length=1
+        length=1,
     )
     axis_w = properties.Vector3(
         'Vector orientation of w-direction',
         default='Z',
-        length=1
+        length=1,
     )
 
     _valid_locations = ('vertices', 'cells')
@@ -76,10 +76,10 @@ class VolumeElement(ProjectElement):
     """Contains mesh, data, and options of a volume"""
     geometry = properties.Instance(
         'Structure of the volume element',
-        instance_class=VolumeGridGeometry
+        instance_class=VolumeGridGeometry,
     )
     subtype = properties.StringChoice(
         'Category of Volume',
         choices=('volume',),
-        default='volume'
+        default='volume',
     )

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -153,7 +153,7 @@ def test_deserialize():
     assert model_a.my_model.date_modified == dates[3]
     assert model_a.my_model.my_int == 1
     input_dict['__root__'] = uid_b
-    properties.extras.HasUID._INSTANCES = {}
+    properties.extras.HasUID._INSTANCES = {}                                   #pylint: disable=protected-access
     model_b = omf.base.UidModel.deserialize(input_dict, trusted=True)
     assert properties.equal(model_b, model_a.my_model)
     #pylint: enable=no-member

--- a/tests/test_doc_example.py
+++ b/tests/test_doc_example.py
@@ -150,6 +150,7 @@ def test_doc_ex():
     omf.OMFWriter(proj, serialfile)
     omf.base.UidModel._INSTANCES = {}                                          #pylint: disable=protected-access
     reader = omf.OMFReader(serialfile)
+    new_proj_overview = reader.get_project_overview()
     new_proj = reader.get_project()
     assert new_proj.validate()
     assert str(new_proj.elements[3].textures[0].uid) == \

--- a/tests/test_doc_example.py
+++ b/tests/test_doc_example.py
@@ -148,6 +148,7 @@ def test_doc_ex():
     assert proj.validate()
     serialfile = os.path.sep.join([dirname, 'out.omf'])
     omf.OMFWriter(proj, serialfile)
+    omf.base.UidModel._INSTANCES = {}
     reader = omf.OMFReader(serialfile)
     new_proj = reader.get_project()
     assert new_proj.validate()

--- a/tests/test_doc_example.py
+++ b/tests/test_doc_example.py
@@ -149,7 +149,7 @@ def test_doc_ex():
     serialfile = os.path.sep.join([dirname, 'out.omf'])
     omf.OMFWriter(proj, serialfile)
     reader = omf.OMFReader(serialfile)
-    new_proj_overview = reader.get_project_overview()
+    reader.get_project_overview()
     new_proj = reader.get_project()
     assert new_proj.validate()
     assert str(new_proj.elements[3].textures[0].uid) == \

--- a/tests/test_doc_example.py
+++ b/tests/test_doc_example.py
@@ -148,7 +148,6 @@ def test_doc_ex():
     assert proj.validate()
     serialfile = os.path.sep.join([dirname, 'out.omf'])
     omf.OMFWriter(proj, serialfile)
-    omf.base.UidModel._INSTANCES = {}                                          #pylint: disable=protected-access
     reader = omf.OMFReader(serialfile)
     new_proj_overview = reader.get_project_overview()
     new_proj = reader.get_project()

--- a/tests/test_doc_example.py
+++ b/tests/test_doc_example.py
@@ -148,7 +148,7 @@ def test_doc_ex():
     assert proj.validate()
     serialfile = os.path.sep.join([dirname, 'out.omf'])
     omf.OMFWriter(proj, serialfile)
-    omf.base.UidModel._INSTANCES = {}
+    omf.base.UidModel._INSTANCES = {}                                          #pylint: disable=protected-access
     reader = omf.OMFReader(serialfile)
     new_proj = reader.get_project()
     assert new_proj.validate()


### PR DESCRIPTION
Previously the UID behaviour was implemented custom within the python OMF implementation. See #64 

This also adds a large number of trailing commas, for consistent style.

Note - This is the first OMFv2 PR to implement breaking changes from the v1 API.