### PR TITLE
[GH-47] Make segments optional on linesets

### DIFF
--- a/omf/lineset.py
+++ b/omf/lineset.py
@@ -18,8 +18,11 @@ class LineSetElement(ProjectElement):
         Vector3Array,
     )
     segments = properties.Instance(
-        'Endpoint vertex indices of line segments',
+        'Endpoint vertex indices of line segments; if segments is not '
+        'specified, the vertices are connected in order, equivalent to '
+        'segments=[[0, 1], [1, 2], [2, 3], ...]',
         Int2Array,
+        required=False,
     )
     subtype = properties.StringChoice(
         'Category of LineSet',
@@ -43,11 +46,15 @@ class LineSetElement(ProjectElement):
     @property
     def num_cells(self):
         """Number of cells (segments)"""
+        if self.segments is None:
+            return len(self.vertices.array) - 1
         return len(self.segments.array)
 
     @properties.validator
     def _validate_mesh(self):
         """Ensures segment indices are valid"""
+        if self.segments is None:
+            return True
         if np.min(self.segments.array) < 0:
             raise ValueError('Segments may only have positive integers')
         if np.max(self.segments.array) >= len(self.vertices.array):

--- a/tests/test_lineset.py
+++ b/tests/test_lineset.py
@@ -9,6 +9,7 @@ def test_lineset():
     """Test lineset geometry validation"""
     elem = omf.lineset.LineSetElement()
     elem.vertices = np.random.rand(10, 3)
+    assert elem.validate()
     elem.segments = np.random.randint(9, size=[5, 2])
     assert elem.validate()
     assert elem.location_length('vertices') == 10


### PR DESCRIPTION
This PR makes `segments` optional on LineSet element. If `segments` is not provided, the standard interpretation is all `vertices` are connected in order - equivalent to:

`segments=[[0, 1], [1, 2], [2, 3], ..., [n-2, n-1]]`

where `n` is `len(vertices)`.