### PR TITLE
[GH-20] Add arbitrary metadata property to project/element/attribute

### DIFF
--- a/docs/content/base.rst
+++ b/docs/content/base.rst
@@ -27,3 +27,18 @@ Uid Model
 UidModel gives all content a name, description, and unique uid.
 
 .. autoclass:: omf.base.UidModel
+
+Metadata Classes
+----------------
+
+.. autoclass:: omf.base.ProjectMetadata
+
+.. autoclass:: omf.base.ElementMetadata
+
+.. autoclass:: omf.base.AttributeMetadata
+
+.. autoclass:: omf.base.BaseMetadata
+
+.. autoclass:: omf.base.ArbitraryMetadataDict
+
+.. autoclass:: omf.base.StringDateTime

--- a/omf/base.py
+++ b/omf/base.py
@@ -135,7 +135,6 @@ class ArbitraryMetadataDict(properties.Dictionary):
     def __init__(self, doc, metadata_class, **kwargs):
         self.metadata_class = metadata_class
         kwargs.update({'key_prop': properties.String('')})
-        doc = '\n\n'.join([doc, metadata_class.__doc__])
         super(ArbitraryMetadataDict, self).__init__(doc, **kwargs)
 
     def validate(self, instance, value):
@@ -176,21 +175,32 @@ class ArbitraryMetadataDict(properties.Dictionary):
             setattr(instance, self.name, new_value)
         return value
 
+    @property
+    def info(self):
+        """Description of the property, supplemental to the basic doc"""
+        info = (
+            'an arbitrary JSON-serializable dictionary, with certain keys '
+            'validated against :class:`{cls} <{pref}.{cls}>`'.format(
+                cls=self.metadata_class.__name__,
+                pref=self.metadata_class.__module__,
+            )
+        )
+        return info
+
 
 class ContentModel(UidModel):
-    """ContentModel is a UidModel with title and description"""
-
+    """ContentModel is a UidModel with name, description, and metadata"""
     name = properties.String(
-        'Title',
-        default=''
+        'Title of the object',
+        default='',
     )
     description = properties.String(
-        'Description',
-        default=''
+        'Description of the object',
+        default='',
     )
     metadata = ArbitraryMetadataDict(
         'Basic object metadata',
-        metadata_class=properties.HasProperties,
+        metadata_class=BaseMetadata,
         default=dict,
     )
 
@@ -200,7 +210,7 @@ class ProjectElementData(ContentModel):
 
     location = properties.StringChoice(
         'Location of the data on mesh',
-        choices=('vertices', 'segments', 'faces', 'cells')
+        choices=('vertices', 'segments', 'faces', 'cells'),
     )
     metadata = ArbitraryMetadataDict(
         'Attribute metadata',

--- a/omf/base.py
+++ b/omf/base.py
@@ -45,13 +45,21 @@ class UidModel(six.with_metaclass(UIDMetaclass, properties.extras.HasUID)):
         return True
 
 
+class StringDateTime(properties.DateTime):
+    """DateTime property validated to be a string"""
+
+    def validate(self, instance, value):
+        value = super(StringDateTime, self).validate(instance, value)
+        return self.to_json(value)
+
+
 class BaseMetadata(properties.HasProperties):
     """Validated metadata properties for all objects"""
-    date_created = properties.String(
+    date_created = StringDateTime(
         'Date object was created',
         required=False,
     )
-    date_modified = properties.String(
+    date_modified = StringDateTime(
         'Date object was modified',
         required=False,
     )
@@ -71,9 +79,9 @@ class ProjectMetadata(BaseMetadata):
         'Revision',
         required=False,
     )
-    date = properties.DateTime(
+    date = StringDateTime(
         'Date associated with the project data',
-        required=False
+        required=False,
     )
 
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,5 +1,5 @@
 """Tests for base UidModel class behaviors"""
-import datetime
+import json
 try:
     from unittest import mock
 except ImportError:
@@ -19,12 +19,76 @@ def test_uid_model(mock_uuid):
     my_id = str(uuid.uuid4())
     mock_uuid.UUID = uuid.UUID
     mock_uuid.uuid4 = lambda: my_id
-    now = datetime.datetime.utcnow()
-    delta = datetime.timedelta(seconds=0.1)
     model = omf.base.UidModel()
     assert model.uid == my_id
-    assert model.date_created - now < delta
-    assert model.date_modified - now < delta
+
+
+class Metadata(properties.HasProperties):
+    """Metadata class for testing"""
+    meta_int = properties.Integer('', required=False)
+    meta_string = properties.String('', required=False)
+    meta_color = properties.Color('', required=False)
+    meta_anything = properties.Property('', required=False)
+
+
+def test_metadata_property():
+    """Test metadata validates predefined keys but allows any keys"""
+
+    class WithMetadata(properties.HasProperties):
+        """Test class with metadata"""
+        metadata = omf.base.ArbitraryMetadataDict(
+            'Some metadata',
+            Metadata,
+            default=dict,
+        )
+
+    with pytest.raises(AttributeError):
+        WithMetadata._props['metadata'].metadata_class = object                #pylint: disable=no-member
+
+    has_metadata = WithMetadata()
+    assert has_metadata.validate()
+    has_metadata.metadata['meta_int'] = 5
+    assert has_metadata.validate()
+    has_metadata.metadata['meta_int'] = 'not an int'
+    with pytest.raises(properties.ValidationError):
+        has_metadata.validate()
+    has_metadata.metadata['meta_int'] = 5
+    has_metadata.metadata['meta_string'] = 'a string'
+    assert has_metadata.validate()
+    has_metadata.metadata['meta_color'] = 'red'
+    assert has_metadata.validate()
+    assert has_metadata.metadata['meta_color'] == (255, 0, 0)
+    has_metadata.metadata['meta_anything'] = 'a string'
+    assert has_metadata.validate()
+    has_metadata.metadata['meta_anything'] = Metadata
+    with pytest.raises(properties.ValidationError):
+        has_metadata.validate()
+    has_metadata.metadata['meta_anything'] = 'a string'
+    has_metadata.metadata['another'] = 'a string'
+    has_metadata.metadata['even another'] = 'a string'
+    assert has_metadata.validate()
+
+    has_metadata.metadata['and another'] = Metadata
+    with pytest.raises(properties.ValidationError):
+        has_metadata.validate()
+    has_metadata.metadata.pop('and another')
+    serialized_has_meta = has_metadata.serialize(include_class=False)
+    assert serialized_has_meta == {
+        'metadata': {
+            'meta_int': 5,
+            'meta_string': 'a string',
+            'meta_color': (255, 0, 0),
+            'meta_anything': 'a string',
+            'another': 'a string',
+            'even another': 'a string',
+        }
+    }
+    new_metadata = WithMetadata.deserialize(
+        json.loads(json.dumps(serialized_has_meta))
+    )
+    new_metadata.validate()
+    assert properties.equal(has_metadata, new_metadata)
+    assert new_metadata.serialize(include_class=False) == serialized_has_meta
 
 
 class MyModelWithInt(omf.base.UidModel):
@@ -35,29 +99,6 @@ class MyModelWithInt(omf.base.UidModel):
 class MyModelWithIntAndInstance(MyModelWithInt):
     """Test class with an integer property and an instance property"""
     my_model = properties.Instance('', omf.base.UidModel)
-
-
-def test_modify():
-    """Test that date_modified updates correctly on set"""
-    model = MyModelWithInt()
-    date_created = model.date_created
-    date_modified = model.date_modified
-    model.my_int = 0
-    assert model.date_created == date_created
-    assert model.date_modified > date_modified
-
-
-def test_validate_updates():
-    """Test that date_modified updates correctly on validate"""
-    model = MyModelWithIntAndInstance(my_int=1)
-    date_created = model.date_created
-    date_modified = model.date_modified
-    model.my_model = MyModelWithInt()
-    model.my_model.my_int = 2
-    model.validate()
-    assert model.date_created == date_created
-    assert model.date_modified > date_modified
-    assert model.date_modified == model.my_model.date_modified
 
 
 @pytest.mark.parametrize('include_class', [True, False])
@@ -93,8 +134,6 @@ def test_uid_model_serialize(include_class, skip_validation, registry):
         assert model.uid in output
         expected_dict = {
             'uid': model.uid,
-            'date_created': properties.DateTime.to_json(model.date_created),
-            'date_modified': properties.DateTime.to_json(model.date_modified),
         }
         if isinstance(model, MyModelWithIntAndInstance):
             expected_dict.update({
@@ -121,20 +160,14 @@ def test_deserialize():
     """Test deserialize correctly builds UidModel from registry"""
     uid_a = str(uuid.uuid4())
     uid_b = str(uuid.uuid4())
-    dates = [datetime.datetime(2019, 1, i) for i in range(1, 5)]
-    string_dates = [properties.DateTime.to_json(d) for d in dates]
     input_dict = {
         uid_a: {
-            'date_created': string_dates[0],
-            'date_modified': string_dates[1],
             'my_int': 0,
             'my_model': uid_b,
             'uid': uid_a,
             '__class__': 'MyModelWithIntAndInstance',
         },
         uid_b: {
-            'date_created': string_dates[2],
-            'date_modified': string_dates[3],
             'my_int': 1,
             'uid': uid_b,
             '__class__': 'MyModelWithInt',
@@ -145,12 +178,8 @@ def test_deserialize():
     assert isinstance(model_a, MyModelWithIntAndInstance)
     #pylint: disable=no-member
     assert str(model_a.uid) == uid_a
-    assert model_a.date_created == dates[0]
-    assert model_a.date_modified == dates[1]
     assert model_a.my_int == 0
     assert isinstance(model_a.my_model, MyModelWithInt)
-    assert model_a.my_model.date_created == dates[2]
-    assert model_a.my_model.date_modified == dates[3]
     assert model_a.my_model.my_int == 1
     input_dict['__root__'] = uid_b
     properties.extras.HasUID._INSTANCES = {}                                   #pylint: disable=protected-access

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,4 +1,5 @@
 """Tests for base UidModel class behaviors"""
+import datetime
 import json
 try:
     from unittest import mock
@@ -29,6 +30,7 @@ class Metadata(properties.HasProperties):
     meta_string = properties.String('', required=False)
     meta_color = properties.Color('', required=False)
     meta_anything = properties.Property('', required=False)
+    meta_date = omf.base.StringDateTime('', required=False)
 
 
 def test_metadata_property():
@@ -64,6 +66,11 @@ def test_metadata_property():
     with pytest.raises(properties.ValidationError):
         has_metadata.validate()
     has_metadata.metadata['meta_anything'] = 'a string'
+    has_metadata.metadata['meta_date'] = 'some date'
+    with pytest.raises(properties.ValidationError):
+        has_metadata.validate()
+    has_metadata.metadata['meta_date'] = datetime.datetime(1980, 1, 1)
+    assert has_metadata.validate()
     has_metadata.metadata['another'] = 'a string'
     has_metadata.metadata['even another'] = 'a string'
     assert has_metadata.validate()
@@ -79,6 +86,7 @@ def test_metadata_property():
             'meta_string': 'a string',
             'meta_color': (255, 0, 0),
             'meta_anything': 'a string',
+            'meta_date': '1980-01-01T00:00:00Z',
             'another': 'a string',
             'even another': 'a string',
         }

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -68,7 +68,7 @@ def test_mapped_data():
     mdata.array.array[0] = 0
     mdata.metadata = {
         'units': 'm',
-        'date_created': str(datetime.datetime.utcnow()),
+        'date_created': datetime.datetime.utcnow(),
         'version': 'v1.3',
     }
     assert mdata.validate()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,4 +1,5 @@
 """Tests for data object validation"""
+import datetime
 import pytest
 
 import omf
@@ -65,6 +66,12 @@ def test_mapped_data():
     with pytest.raises(ValueError):
         mdata.validate()
     mdata.array.array[0] = 0
+    mdata.metadata = {
+        'units': 'm',
+        'date_created': str(datetime.datetime.utcnow()),
+        'version': 'v1.3',
+    }
+    assert mdata.validate()
     mdata.legends.append(
         omf.data.Legend(
             name='short',

--- a/tests/test_doc_example.py
+++ b/tests/test_doc_example.py
@@ -1,4 +1,5 @@
 """Test the example in the docs"""
+import datetime
 import os
 
 import numpy as np
@@ -52,7 +53,9 @@ def test_doc_ex():
                 axis_v=[0, 0, 1],
             ),
         ],
-        color='green',
+        metadata={
+            'color': 'green',
+        },
     )
     lin = omf.LineSetElement(
         name='Random Line',
@@ -70,7 +73,9 @@ def test_doc_ex():
                 location='segments',
             ),
         ],
-        color='#0000FF',
+        metadata={
+            'color': '#0000FF',
+        },
     )
     surf = omf.SurfaceElement(
         name='trisurf',
@@ -88,7 +93,9 @@ def test_doc_ex():
                 location='faces',
             ),
         ],
-        color=[100, 200, 200],
+        metadata={
+            'color': [100, 200, 200],
+        },
     )
     grid = omf.SurfaceGridElement(
         name='gridsurf',
@@ -135,6 +142,12 @@ def test_doc_ex():
         ],
     )
     proj.elements = [pts, lin, surf, grid, vol]
+    proj.metadata = {
+        'coordinate_reference_system': 'epsg 3857',
+        'date_created': str(datetime.datetime.utcnow()),
+        'version': 'v1.3',
+        'revision': '10',
+    }
     assert proj.validate()
     serialfile = os.path.sep.join([dirname, 'out.omf'])
     omf.OMFWriter(proj, serialfile)

--- a/tests/test_doc_example.py
+++ b/tests/test_doc_example.py
@@ -144,7 +144,7 @@ def test_doc_ex():
     proj.elements = [pts, lin, surf, grid, vol]
     proj.metadata = {
         'coordinate_reference_system': 'epsg 3857',
-        'date_created': str(datetime.datetime.utcnow()),
+        'date_created': datetime.datetime.utcnow(),
         'version': 'v1.3',
         'revision': '10',
     }

--- a/tests/test_pointset.py
+++ b/tests/test_pointset.py
@@ -1,4 +1,5 @@
 """Tests for PointSet validation"""
+import datetime
 import numpy as np
 
 import omf
@@ -10,3 +11,9 @@ def test_pointset():
     elem.vertices = np.random.rand(10, 3)
     assert elem.validate()
     assert elem.location_length('vertices') == 10
+    elem.metadata = {
+        'color': 'green',
+        'date_created': str(datetime.datetime.utcnow()),
+        'version': 'v1.3',
+    }
+    assert elem.validate()

--- a/tests/test_pointset.py
+++ b/tests/test_pointset.py
@@ -13,7 +13,7 @@ def test_pointset():
     assert elem.location_length('vertices') == 10
     elem.metadata = {
         'color': 'green',
-        'date_created': str(datetime.datetime.utcnow()),
+        'date_created': datetime.datetime.utcnow(),
         'version': 'v1.3',
     }
     assert elem.validate()


### PR DESCRIPTION
This moves most metadata attributes to `metadata` dictionary on objects. This dictionary has several validated fields to help build consistency across OMF files. However, it also allows for any JSON-serializable metadata.