### PR TITLE
[GH-14] Add UV mapped texture

### DIFF
--- a/docs/content/textures.rst
+++ b/docs/content/textures.rst
@@ -1,12 +1,12 @@
 .. _textures:
 
-Texture
-*******
+Projected Texture
+*****************
 
-Textures are images that exist in space and are mapped to their corresponding
-elements. Unlike data, they do not need to correspond to mesh nodes or
-cell centers. This image shows how textures are mapped to a surface. Their
-position is defined by an origin and axis vectors then they
+Projected textures are images that exist in space and are mapped to their
+corresponding elements. Unlike data, they do not need to correspond to mesh
+nodes or cell centers. This image shows how textures are mapped to a surface.
+Their position is defined by an origin and axis vectors then they
 are mapped laterally to the element position.
 
 .. image:: /images/ImageTexture.png
@@ -26,13 +26,13 @@ nothing requiring the image to actually align with the Surface.
     >> ...
     >> my_surface = omf.SurfaceElement(...)
     >> ...
-    >> my_tex_1 = omf.ImageTexture(
+    >> my_tex_1 = omf.ProjectedTexture(
            origin=[0.0, 0.0, 0.0],
            axis_u=[1.0, 0.0, 0.0],
            axis_v=[0.0, 1.0, 0.0],
            image='image1.png'
        )
-    >> my_tex_2 = omf.ImageTexture(
+    >> my_tex_2 = omf.ProjectedTexture(
            origin=[0.0, 0.0, 0.0],
            axis_u=[1.0, 0.0, 0.0],
            axis_v=[0.0, 0.0, 1.0],
@@ -43,4 +43,14 @@ nothing requiring the image to actually align with the Surface.
            my_tex_2
        ]
 
-.. autoclass:: omf.texture.ImageTexture
+.. autoclass:: omf.texture.ProjectedTexture
+
+
+UV Mapped Textures
+******************
+
+Rather than being projected onto points or a surface, UV Mapped Textures
+are given normalized UV coordinates which correspond to element
+vertices. This allows arbitrary mapping of images to surfaces.
+
+.. autoclass:: omf.texture.UVMappedTexture

--- a/omf/__init__.py
+++ b/omf/__init__.py
@@ -17,7 +17,7 @@ from .data import (ColorArray, ColorData,
 from .lineset import LineSetElement
 from .pointset import PointSetElement
 from .surface import SurfaceElement, SurfaceGridElement
-from .texture import ImageTexture, UVTexture
+from .texture import ProjectedTexture, UVMappedTexture
 from .volume import VolumeGridElement
 
 from .fileio import OMFReader, OMFWriter

--- a/omf/__init__.py
+++ b/omf/__init__.py
@@ -17,7 +17,7 @@ from .data import (ColorArray, ColorData,
 from .lineset import LineSetElement
 from .pointset import PointSetElement
 from .surface import SurfaceElement, SurfaceGridElement
-from .texture import ImageTexture
+from .texture import ImageTexture, UVTexture
 from .volume import VolumeGridElement
 
 from .fileio import OMFReader, OMFWriter

--- a/omf/pointset.py
+++ b/omf/pointset.py
@@ -8,20 +8,14 @@ import properties
 
 from .base import ProjectElement
 from .data import Vector3Array
-from .texture import ImageTexture
+from .texture import HasTexturesMixin
 
 
-class PointSetElement(ProjectElement):
+class PointSetElement(ProjectElement, HasTexturesMixin):
     """Contains point set spatial information and attributes"""
     vertices = properties.Instance(
         'Spatial coordinates of points relative to point set origin',
         Vector3Array,
-    )
-    textures = properties.List(
-        'Images mapped on the element',
-        prop=ImageTexture,
-        required=False,
-        default=list,
     )
     subtype = properties.StringChoice(
         'Category of PointSet',

--- a/omf/surface.py
+++ b/omf/surface.py
@@ -9,17 +9,11 @@ import properties
 
 from .base import ProjectElement
 from .data import Int3Array, ScalarArray, Vector3Array
-from .texture import ImageTexture
+from .texture import HasTexturesMixin
 
 
-class BaseSurfaceElement(ProjectElement):
+class BaseSurfaceElement(ProjectElement, HasTexturesMixin):
     """Base class for surface elements"""
-    textures = properties.List(
-        'Images mapped on the surface element',
-        prop=ImageTexture,
-        required=False,
-        default=list,
-    )
     subtype = properties.StringChoice(
         'Category of Surface',
         choices=('surface',),
@@ -45,7 +39,7 @@ class BaseSurfaceElement(ProjectElement):
         raise NotImplementedError()
 
 
-class SurfaceElement(BaseSurfaceElement):
+class SurfaceElement(BaseSurfaceElement):                                      #pylint: disable=too-many-ancestors
     """Contains triangulated surface spatial information and attributes"""
     vertices = properties.Instance(
         'Spatial coordinates of vertices relative to surface origin',
@@ -75,7 +69,7 @@ class SurfaceElement(BaseSurfaceElement):
         return True
 
 
-class SurfaceGridElement(BaseSurfaceElement):
+class SurfaceGridElement(BaseSurfaceElement):                                  #pylint: disable=too-many-ancestors
     """Contains 2D grid spatial information and attributes"""
     tensor_u = properties.Array(
         'Grid cell widths, u-direction',

--- a/omf/texture.py
+++ b/omf/texture.py
@@ -12,8 +12,8 @@ from .data import Vector2Array
 from .serializers import png_serializer, png_deserializer
 
 
-class ImageTexture(ContentModel):
-    """Contains an image that can be mapped to a point set or surface"""
+class ProjectedTexture(ContentModel):
+    """Contains an image that can be projected onto a point set or surface"""
     origin = properties.Vector3(
         'Origin point of the texture',
         default=[0., 0., 0.],
@@ -33,7 +33,7 @@ class ImageTexture(ContentModel):
     )
 
 
-class UVTexture(ContentModel):
+class UVMappedTexture(ContentModel):
     """Contains an image that is UV mapped to a geometry"""
 
     image = properties.ImagePNG(
@@ -60,7 +60,7 @@ class HasTexturesMixin(properties.HasProperties):
 
     textures = properties.List(
         'Images mapped on the element',
-        prop=properties.Union('', (ImageTexture, UVTexture)),
+        prop=properties.Union('', (ProjectedTexture, UVMappedTexture)),
         required=False,
         default=list,
     )
@@ -71,7 +71,7 @@ class HasTexturesMixin(properties.HasProperties):
         if not hasattr(self, 'num_nodes'):
             return True
         for i, tex in enumerate(self.textures):
-            if isinstance(tex, ImageTexture):
+            if isinstance(tex, ProjectedTexture):
                 continue
             if len(tex.uv_coordinates) != self.num_nodes:
                 raise properties.ValidationError(

--- a/omf/texture.py
+++ b/omf/texture.py
@@ -4,7 +4,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import numpy as np
 import properties
 
 from .base import ContentModel

--- a/omf/texture.py
+++ b/omf/texture.py
@@ -42,17 +42,11 @@ class UVMappedTexture(ContentModel):
         deserializer=png_deserializer,
     )
     uv_coordinates = properties.Instance(
-        'Normalized UV coordinates mapping the image element vertices',
+        'Normalized UV coordinates mapping the image to element vertices; '
+        'for values outside 0-1 the texture repeats at every integer level, '
+        'and NaN indicates no texture at a vertex',
         Vector2Array,
     )
-    @properties.validator
-    def _validate_uv(self):
-        """Validate UV values between 0 and 1"""
-        if np.min(self.uv_coordinates) < 0 or np.max(self.uv_coordinates) > 1:
-            raise properties.ValidationError(
-                'UV coordinates must be between 0 and 1'
-            )
-        return True
 
 
 class HasTexturesMixin(properties.HasProperties):
@@ -75,7 +69,7 @@ class HasTexturesMixin(properties.HasProperties):
                 continue
             if len(tex.uv_coordinates) != self.num_nodes:
                 raise properties.ValidationError(
-                    'data[{index}] length {datalen} does not match '
+                    'texture[{index}] length {datalen} does not match '
                     'vertices length {meshlen}'.format(
                         index=i,
                         datalen=len(tex.uv_coordinates),

--- a/omf/texture.py
+++ b/omf/texture.py
@@ -4,9 +4,11 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import numpy as np
 import properties
 
 from .base import ContentModel
+from .data import Vector2Array
 from .serializers import png_serializer, png_deserializer
 
 
@@ -29,3 +31,55 @@ class ImageTexture(ContentModel):
         serializer=png_serializer,
         deserializer=png_deserializer,
     )
+
+
+class UVTexture(ContentModel):
+    """Contains an image that is UV mapped to a geometry"""
+
+    image = properties.ImagePNG(
+        'PNG image file',
+        serializer=png_serializer,
+        deserializer=png_deserializer,
+    )
+    uv_coordinates = properties.Instance(
+        'Normalized UV coordinates mapping the image element vertices',
+        Vector2Array,
+    )
+    @properties.validator
+    def _validate_uv(self):
+        """Validate UV values between 0 and 1"""
+        if np.min(self.uv_coordinates) < 0 or np.max(self.uv_coordinates) > 1:
+            raise properties.ValidationError(
+                'UV coordinates must be between 0 and 1'
+            )
+        return True
+
+
+class HasTexturesMixin(properties.HasProperties):
+    """Mixin for elements with textures"""
+
+    textures = properties.List(
+        'Images mapped on the element',
+        prop=properties.Union('', (ImageTexture, UVTexture)),
+        required=False,
+        default=list,
+    )
+
+    @properties.validator
+    def _validate_textures(self):
+        """Validate UVTextures against geometry"""
+        if not hasattr(self, 'num_nodes'):
+            return True
+        for i, tex in enumerate(self.textures):
+            if isinstance(tex, ImageTexture):
+                continue
+            if len(tex.uv_coordinates) != self.num_nodes:
+                raise properties.ValidationError(
+                    'data[{index}] length {datalen} does not match '
+                    'vertices length {meshlen}'.format(
+                        index=i,
+                        datalen=len(tex.uv_coordinates),
+                        meshlen=self.num_nodes,
+                    )
+                )
+        return True

--- a/tests/test_doc_example.py
+++ b/tests/test_doc_example.py
@@ -37,14 +37,14 @@ def test_doc_ex():
             ),
         ],
         textures=[
-            omf.ImageTexture(
+            omf.ProjectedTexture(
                 name='test image',
                 image=pngfile,
                 origin=[0, 0, 0],
                 axis_u=[1, 0, 0],
                 axis_v=[0, 1, 0],
             ),
-            omf.ImageTexture(
+            omf.ProjectedTexture(
                 name='test image',
                 image=pngfile,
                 origin=[0, 0, 0],
@@ -111,7 +111,7 @@ def test_doc_ex():
             ),
         ],
         textures=[
-            omf.ImageTexture(
+            omf.ProjectedTexture(
                 name='test image',
                 image=pngfile,
                 origin=[2., 2., 2.],

--- a/tests/test_textures.py
+++ b/tests/test_textures.py
@@ -28,17 +28,17 @@ def setup_texture(func):
 
 
 @setup_texture
-def test_imagetexture(pngfile):
-    """Test image texture validation"""
-    tex = omf.ImageTexture()
+def test_projectedtexture(pngfile):
+    """Test projected texture validation"""
+    tex = omf.ProjectedTexture()
     tex.image = pngfile
     assert tex.validate()
 
 
 @setup_texture
-def test_uvtexture(pngfile):
-    """Test uv texture validation"""
-    tex = omf.UVTexture()
+def test_uvmappedtexture(pngfile):
+    """Test uv mapped texture validation"""
+    tex = omf.UVMappedTexture()
     tex.image = pngfile
     with pytest.raises(properties.ValidationError):
         tex.uv_coordinates = [0., 1., 0.5]

--- a/tests/test_textures.py
+++ b/tests/test_textures.py
@@ -1,5 +1,6 @@
 """Tests for texture validation"""
 import os
+import numpy as np
 import png
 import properties
 import pytest
@@ -43,9 +44,8 @@ def test_uvmappedtexture(pngfile):
     with pytest.raises(properties.ValidationError):
         tex.uv_coordinates = [0., 1., 0.5]
     tex.uv_coordinates = [[0., -0.5], [0.5, 1]]
-    with pytest.raises(properties.ValidationError):
-        tex.validate()
-    tex.uv_coordinates = [[0., 0.5], [0.5, 1]]
+    assert tex.validate()
+    tex.uv_coordinates = [[0., 0.5], [0.5, np.nan]]
     assert tex.validate()
 
     points = omf.PointSetElement()

--- a/tests/test_textures.py
+++ b/tests/test_textures.py
@@ -1,0 +1,57 @@
+"""Tests for texture validation"""
+import os
+import png
+import properties
+import pytest
+
+import omf
+
+
+def setup_texture(func):
+    """Function wrapper to create png image"""
+
+    def new_func():
+        """Create png image and pass to func"""
+        dirname, _ = os.path.split(os.path.abspath(__file__))
+        pngfile = os.path.sep.join([dirname, 'out.png'])
+        img = ['110010010011', '101011010100', '110010110101', '100010010011']
+        img = [[int(val) for val in value] for value in img]
+        writer = png.Writer(len(img[0]), len(img), greyscale=True, bitdepth=16)
+        with open(pngfile, 'wb') as file:
+            writer.write(file, img)
+        try:
+            func(pngfile)
+        finally:
+            os.remove(pngfile)
+
+    return new_func
+
+
+@setup_texture
+def test_imagetexture(pngfile):
+    """Test image texture validation"""
+    tex = omf.ImageTexture()
+    tex.image = pngfile
+    assert tex.validate()
+
+
+@setup_texture
+def test_uvtexture(pngfile):
+    """Test uv texture validation"""
+    tex = omf.UVTexture()
+    tex.image = pngfile
+    with pytest.raises(properties.ValidationError):
+        tex.uv_coordinates = [0., 1., 0.5]
+    tex.uv_coordinates = [[0., -0.5], [0.5, 1]]
+    with pytest.raises(properties.ValidationError):
+        tex.validate()
+    tex.uv_coordinates = [[0., 0.5], [0.5, 1]]
+    assert tex.validate()
+
+    points = omf.PointSetElement()
+    points.vertices = [[0., 0, 0], [1, 1, 1], [2, 2, 2]]
+    points.textures = [tex]
+    with pytest.raises(properties.ValidationError):
+        points.validate()
+    points.vertices = [[0., 0, 0], [1, 1, 1]]
+    assert points.validate()


### PR DESCRIPTION
This is a new texture class for mapping an image to vertices using normalized image UV coordinates. The `uv_coordinates` on the texture must be between 0 and 1 and the length must match the length of the vertices of the element.

Also, the redundantly named `ImageTexture` is renamed slightly more meaningful `ProjectedTexture`.