### PR TITLE
[GH-50] New element: Composite Element

### DIFF
--- a/docs/content/api.rst
+++ b/docs/content/api.rst
@@ -15,6 +15,7 @@ These different elements may have :ref:`data` or image :ref:`textures`.
     lineset
     surface
     volume
+    composite
     data
     textures
     arrays

--- a/docs/content/composite.rst
+++ b/docs/content/composite.rst
@@ -1,0 +1,21 @@
+.. _composites:
+
+Composite Element
+*****************
+
+Composite Elements are used to compose multiple other elements into
+a single, more complex, grouped object.
+
+
+Element
+-------
+
+.. autoclass:: omf.composite.CompositeElement
+
+Data
+----
+
+Data is a list of :ref:`data <data>`. For Composite Elements,
+only :code:`location='elements'` is valid. However, Data may also be
+defined on the child :code:`elements`
+

--- a/docs/content/volume.rst
+++ b/docs/content/volume.rst
@@ -17,6 +17,8 @@ Element
 
 .. autoclass:: omf.volume.VolumeGridElement
 
+.. autoclass:: omf.blockmodel.RegularBlockModel
+
 Data
 ----
 

--- a/omf/__init__.py
+++ b/omf/__init__.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 
 from .base import Project
 from .blockmodel import RegularBlockModel
+from .composite import CompositeElement
 from .data import (ColorArray, ColorData,
                    DateTimeArray, DateTimeColormap, DateTimeData,
                    Int2Array, Int3Array,

--- a/omf/base.py
+++ b/omf/base.py
@@ -86,7 +86,7 @@ class ProjectElementData(ContentModel):
 
     location = properties.StringChoice(
         'Location of the data on mesh',
-        choices=('vertices', 'segments', 'faces', 'cells')
+        choices=('vertices', 'segments', 'faces', 'cells', 'elements')
     )
 
     @property
@@ -124,7 +124,7 @@ class ProjectElement(ContentModel):
         assert self._valid_locations, 'ProjectElement needs _valid_locations'
         for i, dat in enumerate(self.data):
             if dat.location not in self._valid_locations:                      #pylint: disable=protected-access
-                raise ValueError(
+                raise properties.ValidationError(
                     'Invalid location {loc} - valid values: {locs}'.format(
                         loc=dat.location,
                         locs=', '.join(self._valid_locations)                  #pylint: disable=protected-access
@@ -132,7 +132,7 @@ class ProjectElement(ContentModel):
                 )
             valid_length = self.location_length(dat.location)
             if len(dat.array) != valid_length:
-                raise ValueError(
+                raise properties.ValidationError(
                     'data[{index}] length {datalen} does not match '
                     '{loc} length {meshlen}'.format(
                         index=i,

--- a/omf/composite.py
+++ b/omf/composite.py
@@ -1,0 +1,36 @@
+"""composite.py: Element composed of other elements"""
+import properties
+
+from .base import ProjectElement
+from .blockmodel import RegularBlockModel
+from .lineset import LineSetElement
+from .pointset import PointSetElement
+from .surface import SurfaceElement, SurfaceGridElement
+from .volume import VolumeGridElement
+
+
+class CompositeElement(ProjectElement):
+    """Element constructed from other primitive elements"""
+
+    elements = properties.List(
+        'Elements grouped into one composite element',
+        prop=properties.Union('', (
+            RegularBlockModel,
+            LineSetElement,
+            PointSetElement,
+            SurfaceElement,
+            SurfaceGridElement,
+            VolumeGridElement,
+        )),
+        default=list,
+    )
+
+    _valid_locations = ('elements',)
+
+    def location_length(self, location):
+        """Composite element data may only be defined on each element
+
+        Each element within the composite element may also have its own
+        data sets.
+        """
+        return len(self.elements)

--- a/omf/lineset.py
+++ b/omf/lineset.py
@@ -49,7 +49,7 @@ class LineSetElement(ProjectElement):
     def _validate_mesh(self):
         """Ensures segment indices are valid"""
         if np.min(self.segments.array) < 0:
-            raise ValueError('Segments may only have positive integers')
+            raise properties.ValidationError('Segments may only have positive integers')
         if np.max(self.segments.array) >= len(self.vertices.array):
-            raise ValueError('Segments expects more vertices than provided')
+            raise properties.ValidationError('Segments expects more vertices than provided')
         return True

--- a/omf/surface.py
+++ b/omf/surface.py
@@ -69,9 +69,9 @@ class SurfaceElement(BaseSurfaceElement):
     @properties.validator
     def _validate_mesh(self):
         if np.min(self.triangles.array) < 0:
-            raise ValueError('Triangles may only have positive integers')
+            raise properties.ValidationError('Triangles may only have positive integers')
         if np.max(self.triangles.array) >= len(self.vertices.array):
-            raise ValueError('Triangles expects more vertices than provided')
+            raise properties.ValidationError('Triangles expects more vertices than provided')
         return True
 
 
@@ -121,11 +121,11 @@ class SurfaceGridElement(BaseSurfaceElement):
     def _validate_mesh(self):
         """Check if mesh content is built correctly"""
         if not np.abs(self.axis_u.dot(self.axis_v)) < 1e-6:                    #pylint: disable=no-member
-            raise ValueError('axis_u and axis_v must be orthogonal')
+            raise properties.ValidationError('axis_u and axis_v must be orthogonal')
         if self.offset_w is properties.undefined or self.offset_w is None:
             return True
         if len(self.offset_w.array) != self.num_nodes:
-            raise ValueError(
+            raise properties.ValidationError(
                 'Length of offset_w, {zlen}, must equal number of nodes, '
                 '{nnode}'.format(
                     zlen=len(self.offset_w),

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -1,0 +1,24 @@
+"""Tests for Composite Element validation"""
+import numpy as np
+import properties
+import pytest
+
+import omf
+
+
+def test_composite():
+    """Test composite element validation"""
+    elem = omf.CompositeElement()
+    elem.elements = [
+        omf.PointSetElement(vertices=np.random.rand(10, 3)),
+        omf.PointSetElement(vertices=np.random.rand(10, 3)),
+    ]
+    assert elem.validate()
+    assert elem.location_length('elements') == 2
+    elem.data = [
+        omf.ScalarData(array=[1., 2.], location='elements'),
+    ]
+    assert elem.validate()
+    elem.data[0].array = [1., 2., 3.]
+    with pytest.raises(properties.ValidationError):
+        elem.validate()


### PR DESCRIPTION
The Composite Element is composed of a list of other `elements`. This is used for grouping spatial primitives into more complex individual objects.

Attributes may be defined on the Composite Element (these must correspond to each `element` - so if you have 5 `elements`, the attribute array must be length-5). Attributes may also be defined on each individual element.

Note - following up on the discussion here https://github.com/gmggroup/omf/issues/50 I chose to disallow nesting of multiple composite elements. I believe this is still general enough for most use cases, and it eliminates the requirement to implement arbitrarily deep nesting of composite elements when adopting OMF.