### PR TITLE
Corrected Image Links

### DIFF
--- a/docs/content/io.rst
+++ b/docs/content/io.rst
@@ -9,7 +9,7 @@ OMF Writer
 
 Batch export multiple different object types from a geological modeling software package.
 
-.. image:: /images/ProjectExport.png
+.. image:: /docs/images/ProjectExport.png
 
 .. autoclass:: omf.fileio.OMFWriter
 
@@ -19,6 +19,6 @@ OMF Reader
 
 Select which objects from the file are to be imported into a 3D visualization software.
 
-.. image:: /images/ProjectImport.png
+.. image:: /docs/images/ProjectImport.png
 
 .. autoclass:: omf.fileio.OMFReader

--- a/docs/content/lineset.rst
+++ b/docs/content/lineset.rst
@@ -5,13 +5,13 @@ LineSet
 
 Transfer mapped geological contacts from a GIS software package into a 3D modelling software package to help construct a 3D model.
 
-.. image:: /images/LineSet.png
+.. image:: /docs/images/LineSet.png
     :scale: 80%
 
 Element
 -------
 
-.. image:: /images/LineSetGeometry.png
+.. image:: /docs/images/LineSetGeometry.png
     :width: 80%
     :align: center
 

--- a/docs/content/pointset.rst
+++ b/docs/content/pointset.rst
@@ -5,13 +5,13 @@ PointSet
 
 Transfering LIDAR point-cloud data from surveying software into 3D modelling software packages.
 
-.. image:: /images/PointSet.png
+.. image:: /docs/images/PointSet.png
     :scale: 80%
 
 Element
 -------
 
-.. image:: /images/PointSetGeometry.png
+.. image:: /docs/images/PointSetGeometry.png
     :width: 80%
     :align: center
 

--- a/docs/content/surface.rst
+++ b/docs/content/surface.rst
@@ -5,17 +5,17 @@ Surface
 
 Transfer geological domains from 3D modelling software to Resource Estimation software.
 
-.. image:: /images/Surface.png
+.. image:: /docs/images/Surface.png
 
 Elements
 --------
 
-.. image:: /images/SurfaceGeometry.png
+.. image:: /docs/images/SurfaceGeometry.png
     :align: center
 
 .. autoclass:: omf.surface.SurfaceElement
 
-.. image:: /images/SurfaceGridGeometry.png
+.. image:: /docs/images/SurfaceGridGeometry.png
     :align: center
 
 .. autoclass:: omf.surface.SurfaceGridElement

--- a/docs/content/textures.rst
+++ b/docs/content/textures.rst
@@ -9,7 +9,7 @@ nodes or cell centers. This image shows how textures are mapped to a surface.
 Their position is defined by an origin and axis vectors then they
 are mapped laterally to the element position.
 
-.. image:: /images/ImageTexture.png
+.. image:: /docs/images/ImageTexture.png
 
 Like data, multiple textures can be applied to a element; simply provide a
 list of textures. Each of these textures provides an origin point and two

--- a/docs/content/volume.rst
+++ b/docs/content/volume.rst
@@ -5,13 +5,13 @@ Volume
 
 Transferring a block model from Resource Estimation software into Mine planning software.
 
-.. image:: /images/VolumeGrid.png
+.. image:: /docs/images/VolumeGrid.png
     :scale: 80%
 
 Element
 -------
 
-.. image:: /images/VolumeGridGeometry.png
+.. image:: /docs/images/VolumeGridGeometry.png
     :width: 80%
     :align: center
 


### PR DESCRIPTION
The original image links led to 404 errors.  They were missing '/docs', which I have added.  Sorry for the unrelated branch name.